### PR TITLE
Pyghmi fallback (#61)

### DIFF
--- a/_modules/redfish.py
+++ b/_modules/redfish.py
@@ -1,7 +1,7 @@
 ## redfish module - primarily used for bootstrapping
 ## could potentially be fleshed out and become formal fully-featured
 ## salt module
-import redfish, json, ipaddress, socket, requests, urllib3, re
+import redfish, pyghmi.ipmi.cmd, json, ipaddress, socket, requests, urllib3, re
 
 urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
 socket.setdefaulttimeout(0.1)
@@ -68,7 +68,12 @@ def set_bootonce(host, username, password, mode, target):
                                     }
                                   })
     session.logout()
-    return response.text
+    if response.status != 200:
+        cmd = pyghmi.ipmi.command.Command(bmc=host, userid=username, password=password, keepalive=False)
+        cmd.set_bootdev(bootdev="network", uefiboot=True)
+        return cmd.get_bootdev()
+    else:
+        return response.text
 
 def reset_host(host, username, password):
     session = login(host, username, password)

--- a/formulas/pxe/install.sls
+++ b/formulas/pxe/install.sls
@@ -24,6 +24,12 @@ redfish_pip:
     - bin_env: '/usr/bin/pip3'
     - reload_modules: True
 
+pyghmi_pip:
+  pip.installed:
+    - name: pyghmi
+    - bin_env: '/usr/bin/pip3'
+    - reload_modules: True
+
 salt-minion_inotify_watch:
   cmd.run:
     - name: 'salt-call service.restart salt-minion'


### PR DESCRIPTION
* Update redfish.py

Add a pyghmi fallback to set_bootonce to support old firmware that does not support BootSourceOverrideMode in redfish.

* add pyghmi to pxe