### PR TITLE
Barbican: add sane high quota defaults 

### DIFF
--- a/formulas/barbican/files/barbican.conf
+++ b/formulas/barbican/files/barbican.conf
@@ -34,7 +34,14 @@ enable = True
 [oslo_policy]
 [p11_crypto_plugin]
 [queue]
+
 [quotas]
+quota_secrets = 1000
+quota_orders = 1000
+quota_containers = 1000
+quota_consumers = 1000
+quota_cas = 1000
+
 [retry_scheduler]
 
 [secretstore]


### PR DESCRIPTION
For barbican quota's by default its unilimted, a tenant can fill the database by claiming unlimited secrets.