### PR TITLE
Barbican: make host_href an empty key 

### DIFF
--- a/formulas/barbican/configure.sls
+++ b/formulas/barbican/configure.sls
@@ -60,7 +60,6 @@ spawnzero_complete:
           {%- endfor %}
         password: {{ pillar['barbican']['barbican_service_password'] }}
         kek: kek = '{{ pillar['barbican']['simplecrypto_key'] }}'
-        host_href: host_href = {{ pillar ['openstack_services']['barbican']['configuration']['public_endpoint']['protocol'] }}{{ pillar['endpoints']['public'] }}{{ pillar ['openstack_services']['barbican']['configuration']['public_endpoint']['port'] }}
 
 {% if grains['os_family'] == 'RedHat' %}
 /etc/httpd/conf.d/wsgi-barbican.conf:

--- a/formulas/barbican/files/barbican.conf
+++ b/formulas/barbican/files/barbican.conf
@@ -1,7 +1,7 @@
 [DEFAULT]
 transport_url = {{ transport_url }}
 {{ sql_connection_string }}
-{{ host_href }}
+host_href = 
 [certificate]
 [certificate_event]
 [cors]


### PR DESCRIPTION
By making the host_href key empty it supports internal and public endpoint returns.

When requesting a secret it returns secret_href url based on which endpoint the user uses. If you use internal endpoint for retrieving a secret you will receive an internal secret_href url.