### PR TITLE
Memcached: increase memory and maxconn of memcached

### DIFF
--- a/formulas/memcached/files/memcached
+++ b/formulas/memcached/files/memcached
@@ -1,5 +1,5 @@
 PORT="11211"
 USER="memcached"
-MAXCONN="1024"
-CACHESIZE="64"
+MAXCONN="2048"
+CACHESIZE="2048"
 OPTIONS="-l 127.0.0.1,::1,{{ listen_addr }}"

--- a/formulas/memcached/files/memcached.conf
+++ b/formulas/memcached/files/memcached.conf
@@ -2,7 +2,7 @@
 
 logfile /var/log/memcached.log
 
--m 64
+-m 2048
 
 -p 11211
 


### PR DESCRIPTION
64mb for memcache is too low for a reasonable sized cloud. Increase to 2048Mb