### PR TITLE
Nova: Reserve some host memory

### DIFF
--- a/formulas/nova/files/nova.conf
+++ b/formulas/nova/files/nova.conf
@@ -9,6 +9,7 @@ memcached_servers = {{ memcached_servers }}
 vnc_enabled = false
 web=/usr/share/spice-html5
 use_syslog = True
+reserved_host_memory_mb=16384
 
 [api]
 auth_strategy = keystone
@@ -16,7 +17,12 @@ auth_strategy = keystone
 [api_database]
 {{ api_sql_connection_string }}
 
+[key_manager]
+backend = barbican
+auth_url = {{ www_authenticate_uri }}
+
 [barbican]
+barbican_endpoint_type = internal
 
 [cache]
 enabled = True
@@ -48,7 +54,6 @@ api_servers = {{ api_servers }}
 [healthcheck]
 [hyperv]
 [ironic]
-[key_manager]
 [keystone]
 
 [keystone_authtoken]


### PR DESCRIPTION
Reserve host memory for computes in order to prevent OOM killers when spawning to much instnaces on computes