### PR TITLE
Nova: add reserve compute memory

### DIFF
--- a/formulas/nova/files/nova.conf
+++ b/formulas/nova/files/nova.conf
@@ -9,6 +9,7 @@ memcached_servers = {{ memcached_servers }}
 vnc_enabled = false
 web=/usr/share/spice-html5
 use_syslog = True
+reserved_host_memory_mb=16384
 
 [api]
 auth_strategy = keystone


### PR DESCRIPTION
Add compute reserved host memory in order to prevent OOM killer kill compute services when to much instances are spawned on compute.