### PR TITLE
Other roots

### DIFF
--- a/formulas/salt/configure.sls
+++ b/formulas/salt/configure.sls
@@ -74,6 +74,12 @@ api:
             - saltenv:
               - base:
                 - ref: {{ pillar['gitfs_remote_configuration']['branch'] }}
+{% for remote, config in pillar.get('gitfs_other_configurations', {}).items() %}
+          - {{ pillar['gitfs_other_configurations'][remote]['url'] }}
+            - saltenv:
+              - base:
+                - ref: {{ pillar['gitfs_other_configurations'][remote]['branch'] }}
+{% endfor %}                
         gitfs_saltenv_whitelist:
           - base
 
@@ -82,6 +88,9 @@ api:
   file.managed:
     - contents_pillar: master-config:{{ directive }}
 {% endfor %}
+
+{% for remote, config in pillar.get('gitfs_other_configurations', {}).items() %}
+
 
 /srv/dynamic_pillar:
   file.directory

--- a/formulas/salt/configure.sls
+++ b/formulas/salt/configure.sls
@@ -79,7 +79,7 @@ api:
             - saltenv:
               - base:
                 - ref: {{ pillar['gitfs_other_configurations'][remote]['branch'] }}
-{% endfor %}                
+{% endfor %}
         gitfs_saltenv_whitelist:
           - base
 
@@ -88,9 +88,6 @@ api:
   file.managed:
     - contents_pillar: master-config:{{ directive }}
 {% endfor %}
-
-{% for remote, config in pillar.get('gitfs_other_configurations', {}).items() %}
-
 
 /srv/dynamic_pillar:
   file.directory

--- a/formulas/salt/configure.sls
+++ b/formulas/salt/configure.sls
@@ -61,7 +61,7 @@ api:
     - contents: |
         ext_pillar:
           - git:
-            - {{ pillar['gitfs_pillar_configuration']['branch'] }} {{ pillar['gitfs_pillar_configuration']['url'] }}:
+            - {{ pillar['kinetic_pillar_configuration']['branch'] }} {{ pillar['kinetic_pillar_configuration']['url'] }}:
               - env: base
         ext_pillar_first: False
         pillar_gitfs_ssl_verify: True
@@ -70,10 +70,10 @@ api:
   file.managed:
     - contents: |
         gitfs_remotes:
-          - {{ pillar['gitfs_remote_configuration']['url'] }}:
+          - {{ pillar['kinetic_remote_configuration']['url'] }}:
             - saltenv:
               - base:
-                - ref: {{ pillar['gitfs_remote_configuration']['branch'] }}
+                - ref: {{ pillar['kinetic_remote_configuration']['branch'] }}
 {% for remote, config in pillar.get('gitfs_other_configurations', {}).items() %}
           - {{ pillar['gitfs_other_configurations'][remote]['url'] }}
             - saltenv:


### PR DESCRIPTION
Closes #10 .  Additional gitfs remotes may be defined in the user pillar, otherwise an empty dictionary, e.g. {} is acceptable.