### PR TITLE
Cell update

### DIFF
--- a/formulas/nova/configure.sls
+++ b/formulas/nova/configure.sls
@@ -52,7 +52,6 @@ update_cells:
     - name: nova-manage cell_v2 list_cells | grep cell1 | cut -d" " -f4 | while read uuid;do nova-manage cell_v2 update_cell --cell_uuid $uuid;done
     - onchanges:
       - file: /etc/nova/nova.conf
-      - file: /etc/neutron/neutron.conf
     - watch_in:
       - service: nova_api_service
       - service: nova_scheduler_service

--- a/formulas/nova/configure.sls
+++ b/formulas/nova/configure.sls
@@ -53,6 +53,11 @@ update_cells:
     - onchanges:
       - file: /etc/nova/nova.conf
       - file: /etc/neutron/neutron.conf
+    - watch_in:
+      - service: nova_api_service
+      - service: nova_scheduler_service
+      - service: nova_conductor_service
+      - service: nova_spiceproxy_service
 
 spawnzero_complete:
   grains.present:
@@ -163,7 +168,6 @@ nova_api_service:
         interval: 10
     - watch:
       - file: /etc/nova/nova.conf
-      - cmd: update_cells
 
 nova_scheduler_service:
   service.running:
@@ -178,7 +182,6 @@ nova_scheduler_service:
         interval: 10
     - watch:
       - file: /etc/nova/nova.conf
-      - cmd: update_cells
 
 nova_conductor_service:
   service.running:
@@ -193,7 +196,6 @@ nova_conductor_service:
         interval: 10
     - watch:
       - file: /etc/nova/nova.conf
-      - cmd: update_cells
 
 nova_spiceproxy_service:
   service.running:
@@ -208,4 +210,3 @@ nova_spiceproxy_service:
         interval: 10
     - watch:
       - file: /etc/nova/nova.conf
-      - cmd: update_cells      

--- a/formulas/nova/configure.sls
+++ b/formulas/nova/configure.sls
@@ -47,6 +47,13 @@ nova-manage db sync:
     - unless:
       - nova-manage db version | grep -q 407
 
+update_cells:
+  cmd.run:
+    - name: nova-manage cell_v2 list_cells | grep cell1 | cut -d" " -f4 | while read uuid;do nova-manage cell_v2 update_cell --cell_uuid $uuid;done
+    - onchanges:
+      - file: /etc/nova/nova.conf
+      - file: /etc/neutron/neutron.conf
+
 spawnzero_complete:
   grains.present:
     - value: True
@@ -156,6 +163,7 @@ nova_api_service:
         interval: 10
     - watch:
       - file: /etc/nova/nova.conf
+      - cmd: update_cells
 
 nova_scheduler_service:
   service.running:
@@ -170,6 +178,7 @@ nova_scheduler_service:
         interval: 10
     - watch:
       - file: /etc/nova/nova.conf
+      - cmd: update_cells
 
 nova_conductor_service:
   service.running:
@@ -184,6 +193,7 @@ nova_conductor_service:
         interval: 10
     - watch:
       - file: /etc/nova/nova.conf
+      - cmd: update_cells
 
 nova_spiceproxy_service:
   service.running:
@@ -198,3 +208,4 @@ nova_spiceproxy_service:
         interval: 10
     - watch:
       - file: /etc/nova/nova.conf
+      - cmd: update_cells      


### PR DESCRIPTION
Closes #26 .  Uses nova-manage to determine cell uuid and then runs update routine if it detects changes in nova.conf.  Also forces service restarts if it runs so services become aware of db changes.