### PR TITLE
Interface assignment

### DIFF
--- a/orch/states/virtual_prep.sls
+++ b/orch/states/virtual_prep.sls
@@ -11,7 +11,7 @@
         ram: {{ pillar['hosts'][type]['ram'] }}
         cpu: {{ pillar['hosts'][type]['cpu'] }}
         networks: |
-        {% for network, attribs in pillar['hosts'][type]['networks'] %}
+        {% for network, attribs in pillar['hosts'][type]['networks'].items() %}
         {% set slot = attribs['interfaces'][0].split['ens'][1] %}
           <interface type='bridge'>
             <source bridge='{{ network }}_br'/>

--- a/orch/states/virtual_prep.sls
+++ b/orch/states/virtual_prep.sls
@@ -51,7 +51,6 @@ qemu-img resize -f raw /kvm/vms/{{ hostname }}/disk0.raw {{ pillar['hosts'][type
     - defaults:
         hostname: {{ hostname }}
         master_record: {{ pillar['master_record'] }}
-        transport: {{ pillar['salt_transport'] }}
 
 genisoimage -o /kvm/vms/{{ hostname }}/config.iso -V cidata -r -J /kvm/vms/{{ hostname }}/data/meta-data /kvm/vms/{{ hostname }}/data/user-data:
   cmd.run:

--- a/orch/states/virtual_prep.sls
+++ b/orch/states/virtual_prep.sls
@@ -11,13 +11,13 @@
         ram: {{ pillar['hosts'][type]['ram'] }}
         cpu: {{ pillar['hosts'][type]['cpu'] }}
         networks: |
-        {% for network in pillar['hosts'][type]['networks']|sort() %}
+        {% for network, attribs in pillar['hosts'][type]['networks'] %}
+        {% set slot = attribs['interfaces'][0].split['ens'][1] %}
           <interface type='bridge'>
             <source bridge='{{ network }}_br'/>
-            <target dev='vnet{{ loop.index0 }}'/>
             <model type='virtio'/>
-            <alias name='net{{ loop.index0 }}'/>
             <mac address='{{ salt['generate.mac']('52:54:00') }}'/>
+            <address type='pci' domain='0x0000' bus='0x00' slot='0x{{ slot }}' function='0x0'/>
           </interface>
         {% endfor %}
         {% if grains['os_family'] == 'Debian' %}

--- a/orch/states/virtual_prep.sls
+++ b/orch/states/virtual_prep.sls
@@ -12,7 +12,7 @@
         cpu: {{ pillar['hosts'][type]['cpu'] }}
         networks: |
         {% for network, attribs in pillar['hosts'][type]['networks'].items() %}
-        {% set slot = attribs['interfaces'][0].split['ens'][1] %}
+        {% set slot = attribs['interfaces'][0].split('ens')[1] %}
           <interface type='bridge'>
             <source bridge='{{ network }}_br'/>
             <model type='virtio'/>


### PR DESCRIPTION
Closes #65 .  Interfaces now get assigned by the specified interface value in the pillar (e.g. using ens3 in the pillar will ensure that the bridge gets assigned to pci slot 0x03).  Interface order no longer matters.