### PR TITLE
Fix missing colon in gitfs_other_configurations

### DIFF
--- a/formulas/salt/configure.sls
+++ b/formulas/salt/configure.sls
@@ -91,7 +91,7 @@ api:
               - base:
                 - ref: {{ pillar['kinetic_remote_configuration']['branch'] }}
 {% for remote, config in pillar.get('gitfs_other_configurations', {}).items() %}
-          - {{ pillar['gitfs_other_configurations'][remote]['url'] }}
+          - {{ pillar['gitfs_other_configurations'][remote]['url'] }}:
             - saltenv:
               - base:
                 - ref: {{ pillar['gitfs_other_configurations'][remote]['branch'] }}


### PR DESCRIPTION
In the current code when a repo was added via the
gitfs_remote_configuration variables in pillar, it would cause an
rendering error when trying to start the salt-master service. This was
due to a missing colon after the url.